### PR TITLE
Add Windows support for URL opening and scripting

### DIFF
--- a/Constella Horizon/AI/AIContextManager.swift
+++ b/Constella Horizon/AI/AIContextManager.swift
@@ -7,7 +7,12 @@
 
 import Foundation
 import Combine
+#if os(macOS)
 import AppKit
+#endif
+#if os(Windows)
+import WinSDK
+#endif
 import CoreGraphics
 import Vision
 
@@ -184,6 +189,10 @@ class AIContextManager: ObservableObject {
 
     /// Returns the cleaned URL (without scheme or “www.”) of the active tab for the specified browser, if available.
     private func getBrowserURL(_ appName: String) -> String? {
+#if os(Windows)
+        guard let script = getWindowsScriptText(appName) else { return nil }
+        return runPowerShellScript(script)
+#else
         guard let scriptText = getScriptText(appName) else { return nil }
 
         var error: NSDictionary?
@@ -196,7 +205,6 @@ class AIContextManager: ObservableObject {
             return nil
         }
 
-        // Clean URL output – remove protocol & unnecessary "www."
         if let url = URL(string: outputString), var host = url.host {
             if host.hasPrefix("www.") {
                 host = String(host.dropFirst(4))
@@ -206,6 +214,7 @@ class AIContextManager: ObservableObject {
         }
 
         return nil
+#endif
     }
 
     /// AppleScript source for fetching the front-most tab/document URL for supported browsers.
@@ -219,6 +228,20 @@ class AIContextManager: ObservableObject {
             return nil
         }
     }
+
+#if os(Windows)
+    /// PowerShell snippet for fetching the active tab URL for supported browsers on Windows.
+    private func getWindowsScriptText(_ appName: String) -> String? {
+        switch appName {
+        case "Google Chrome":
+            return "$sh=New-Object -ComObject Shell.Application;$u=$null;foreach($w in $sh.Windows()){if($w.FullName -match 'chrome.exe$'){$u=$w.Document.URL;break}};$u"
+        case "Safari":
+            return "$sh=New-Object -ComObject Shell.Application;$u=$null;foreach($w in $sh.Windows()){if($w.FullName -match 'msedge.exe$'){$u=$w.Document.URL;break}};$u"
+        default:
+            return nil
+        }
+    }
+#endif
     
 }
 

--- a/Constella Horizon/Auth/AuthManager.swift
+++ b/Constella Horizon/Auth/AuthManager.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 import SwiftUI
+#if os(macOS)
 import AppKit
+#endif
 
 extension Notification.Name {
     static let authStatusChanged = Notification.Name("AuthStatusChanged")
@@ -100,7 +102,7 @@ class AuthManager: NSObject {
         let authURL = "https://onhorizon.ai/auth?fromHorizon=true&callback=\(encodedCallback)"
         
         if let url = URL(string: authURL) {
-            NSWorkspace.shared.open(url)
+            openExternalURL(url)
         }
     }
     

--- a/Constella Horizon/Settings/SettingsView.swift
+++ b/Constella Horizon/Settings/SettingsView.swift
@@ -521,7 +521,7 @@ struct SettingsView: View {
                             if authModel.isAuthenticated {
                                 Button {
                                     if let url = URL(string: "https://www.constella.app/auth/account") {
-                                        NSWorkspace.shared.open(url)
+                                        openExternalURL(url)
                                     }
                                 } label: {
                                     Text("Manage Account")

--- a/Constella Horizon/Setup/FloatingOnboardingTemplate.swift
+++ b/Constella Horizon/Setup/FloatingOnboardingTemplate.swift
@@ -523,14 +523,14 @@ struct FloatingOnboarding: View {
             onLinkClick: {
                 // Open Medium article
                 if let url = URL(string: "https://medium.com/@amanatulla1606/transformer-architecture-explained-2c49e2257b4c") {
-                    NSWorkspace.shared.open(url)
+                    openExternalURL(url)
                 }
                 advanceToNextStep()
             },
             onDiscordClick: {
                 // Open Discord invite
                 if let url = URL(string: "https://discord.gg/XwEhrdJt8H") {
-                    NSWorkspace.shared.open(url)
+                    openExternalURL(url)
                 }
             },
 //             onSlackClick: {
@@ -542,7 +542,7 @@ struct FloatingOnboarding: View {
             onXClick: {
                 // Open X/Twitter community
                 if let url = URL(string: "https://x.com/heyconstella") {
-                    NSWorkspace.shared.open(url)
+                    openExternalURL(url)
                 }
             },
             onShortcutUpdate: { newShortcut in

--- a/Constella Horizon/Setup/PermissionManager.swift
+++ b/Constella Horizon/Setup/PermissionManager.swift
@@ -5,7 +5,9 @@
 //  Created by occlusion on 5/4/25.
 //
 
+#if os(macOS)
 import Cocoa
+#endif
 
 
 class PermissionModel: ObservableObject {
@@ -113,7 +115,7 @@ class PermissionManager: NSObject{
             DispatchQueue.main.asyncAfter(deadline: .now()+1.0, execute: {
                 let urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
                 if let aString = URL(string: urlString) {
-                    NSWorkspace.shared.open(aString)
+                    openExternalURL(aString)
                 }
             })
         }
@@ -127,7 +129,7 @@ class PermissionManager: NSObject{
             DispatchQueue.main.asyncAfter(deadline: .now()+1.0, execute: {
                 let urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
                 if let aString = URL(string: urlString) {
-                    NSWorkspace.shared.open(aString)
+                    openExternalURL(aString)
                 }
             })
         }

--- a/Constella Horizon/Utility/PlatformUtils.swift
+++ b/Constella Horizon/Utility/PlatformUtils.swift
@@ -1,0 +1,48 @@
+import Foundation
+#if os(macOS)
+import AppKit
+#endif
+#if os(Windows)
+import WinSDK
+#endif
+
+/// Opens a URL using the appropriate platform API.
+func openExternalURL(_ url: URL) {
+#if os(Windows)
+    url.absoluteString.withCString(encodedAs: UTF16.self) { lpFile in
+        "open".withCString(encodedAs: UTF16.self) { lpOperation in
+            _ = ShellExecuteW(nil, lpOperation, lpFile, nil, nil, SW_SHOWNORMAL)
+        }
+    }
+#else
+    NSWorkspace.shared.open(url)
+#endif
+}
+
+#if os(Windows)
+/// Executes a PowerShell script and returns its standard output.
+func runPowerShellScript(_ script: String) -> String? {
+    let fileURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString + ".ps1")
+    do {
+        try script.write(to: fileURL, atomically: true, encoding: .utf8)
+    } catch {
+        return nil
+    }
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "powershell.exe")
+    process.arguments = ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", fileURL.path]
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    do {
+        try process.run()
+    } catch {
+        return nil
+    }
+    process.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+#endif


### PR DESCRIPTION
## Summary
- implement cross-platform helpers using `ShellExecuteW` and PowerShell
- use `openExternalURL` across the app to open links
- run PowerShell scripts on Windows for browser URL retrieval
- update imports with platform guards

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6863ad1dfd1c8326952053bf516a83c0