### PR TITLE
Add Windows build config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.16)
+project(HorizonOverlayWin LANGUAGES Swift)
+
+find_package(SwiftWin32 REQUIRED CONFIG)
+
+add_executable(QuickCaptureApp
+    "Constella Horizon/Windows/QuickCaptureWindowWin.swift"
+)
+
+# Required due to SR-12683 when using @main
+# This ensures the app is built correctly on Windows
+# See SwiftWin32 documentation for details
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  target_compile_options(QuickCaptureApp PRIVATE -parse-as-library)
+endif()
+
+target_link_libraries(QuickCaptureApp PRIVATE SwiftWin32)

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "HorizonOverlay",
+    products: [
+        .executable(name: "QuickCaptureApp", targets: ["QuickCaptureApp"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/compnerd/swift-win32.git", branch: "main")
+    ],
+    targets: [
+        .executableTarget(
+            name: "QuickCaptureApp",
+            dependencies: [
+                .product(name: "SwiftWin32", package: "swift-win32")
+            ],
+            path: "Constella Horizon/Windows"
+        )
+    ]
+)


### PR DESCRIPTION
## Summary
- add `Package.swift` for building the Windows demo with Swift Package Manager
- add `CMakeLists.txt` using `SwiftWin32` for a Windows build

## Testing
- `swift build` *(fails: invalid manifest path in dependency)*
- `cmake -B build -S .` *(fails: Swift language not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6863afa82ed483269530274ab2c1c2ad