### PR TITLE
Switch to WinSparkle on Windows

### DIFF
--- a/Constella Horizon/ConstellaHorizonApp.swift
+++ b/Constella Horizon/ConstellaHorizonApp.swift
@@ -10,19 +10,28 @@ import AppKit
 import Carbon
 import Vision
 import ScreenCaptureKit
+#if os(macOS)
 import Sparkle
+#endif
 class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, ObservableObject {
     
     static var shared: AppDelegate!
     lazy var settingsWindow = SettingsWindowController()
     var setupWindow = SetupWindowController()
+    #if os(macOS)
     let updaterController: SPUStandardUpdaterController
- 
+
     override init() {
         updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
         super.init()
         AppDelegate.shared = self
     }
+    #else
+    override init() {
+        super.init()
+        AppDelegate.shared = self
+    }
+    #endif
 
     
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/Constella Horizon/SystemMenu/SystemMenuManager.swift
+++ b/Constella Horizon/SystemMenu/SystemMenuManager.swift
@@ -5,6 +5,7 @@
 //  Created by occlusion on 5/5/25.
 //
 
+#if os(macOS)
 import Cocoa
 import Sparkle
 
@@ -28,7 +29,7 @@ class SystemMenuManager {
         let item1 = NSMenuItem(title: "Settings", action: #selector(openSettings), keyEquivalent:"")
         item1.target = self
     
-        let item2 = NSMenuItem(title: "Check For Update...", action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)), keyEquivalent:"")
+        let item2 = NSMenuItem(title: "Check For Update...", action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)), keyEquivalent: "")
         item2.target = AppDelegate.shared.updaterController
     
         let item3 = NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent:"")
@@ -51,5 +52,9 @@ class SystemMenuManager {
     @objc private func quit() {
         NSApp.terminate(nil)
     }
-    
+
+
 }
+
+#endif
+

--- a/Constella Horizon/Windows/QuickCaptureWindowWin.swift
+++ b/Constella Horizon/Windows/QuickCaptureWindowWin.swift
@@ -1,6 +1,7 @@
 #if os(Windows)
 import SwiftWin32
 import WinSDK
+// WinSparkleManager provides update integration
 
 /// A simple Quick Capture overlay replicated for Windows using SwiftWin32.
 /// This mirrors the macOS `QuickCaptureWindow` structure with a text field
@@ -30,6 +31,17 @@ final class QuickCaptureWindowWin: Window {
 @main
 final class QuickCaptureApp: ApplicationDelegate, SceneDelegate {
     var window: Window!
+
+    func application(_ application: Application,
+                     didFinishLaunchingWithOptions options: [Application.LaunchOptionsKey : Any]?) -> Bool {
+        WinSparkleManager.initialize()
+        WinSparkleManager.checkForUpdates()
+        return true
+    }
+
+    func applicationWillTerminate(_ application: Application) {
+        WinSparkleManager.cleanUp()
+    }
 
     func sceneDidLoad(_ scene: Scene) {
         window = QuickCaptureWindowWin()

--- a/Constella Horizon/Windows/WinSparkleManager.swift
+++ b/Constella Horizon/Windows/WinSparkleManager.swift
@@ -1,0 +1,25 @@
+#if os(Windows)
+import WinSDK
+
+@_silgen_name("win_sparkle_init")
+func win_sparkle_init()
+@_silgen_name("win_sparkle_cleanup")
+func win_sparkle_cleanup()
+@_silgen_name("win_sparkle_check_update_with_ui")
+func win_sparkle_check_update_with_ui()
+
+/// Simple wrapper around WinSparkle C API for Swift usage.
+enum WinSparkleManager {
+    static func initialize() {
+        win_sparkle_init()
+    }
+
+    static func cleanUp() {
+        win_sparkle_cleanup()
+    }
+
+    static func checkForUpdates() {
+        win_sparkle_check_update_with_ui()
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- wrap Sparkle code so it only builds on macOS
- add WinSparkleManager to call WinSparkle C API
- initialize WinSparkle when running the Windows app

## Testing
- `swiftc -parse 'Constella Horizon/Windows/WinSparkleManager.swift'`
- `swiftc -parse 'Constella Horizon/Windows/QuickCaptureWindowWin.swift'`
- `swiftc -parse 'Constella Horizon/ConstellaHorizonApp.swift'`
- `swiftc -parse 'Constella Horizon/SystemMenu/SystemMenuManager.swift'`


------
https://chatgpt.com/codex/tasks/task_e_6863afd936dc83268805498bbbcd74c9